### PR TITLE
Replace default action name with placeholder

### DIFF
--- a/src/CurrentDayContext.tsx
+++ b/src/CurrentDayContext.tsx
@@ -77,7 +77,7 @@ export const CurrentDayProvider: React.FC<{ children: ReactNode }> = ({ children
     }
     const newAction: Action = {
       id: crypto.randomUUID(),
-      label: "New Item",
+      label: "",
       price: EMPTY_CURRENCY(),
       count: 0,
       isFavorite: false,

--- a/src/components/ItemCards/EditableItemCard.tsx
+++ b/src/components/ItemCards/EditableItemCard.tsx
@@ -53,7 +53,7 @@ export default function EditableItemCard({ action, onChange, onDelete, onReorder
       </div>
       
       <div className="label">
-        <input value={action.label} onChange={(e) => setLabel(e.target.value)} />
+        <input value={action.label} placeholder="🗡️Action name" onChange={(e) => setLabel(e.target.value)} />
       </div>
 
       <div className="item-toolbar">


### PR DESCRIPTION
Creating a new action requires the user to delete the existing default name. This was annoying and has been replaced using the "placeholder" property of the text box.

Closes #18 